### PR TITLE
Remove unused npm-name dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,5 @@
     "ecmaFeatures": {
       "modules": true
     }
-  },
-  "dependencies": {
-    "npm-name": "^5.0.1"
   }
 }


### PR DESCRIPTION
This dependency seems unused and causes the module installation to pull in a good number of unneeded dependencies.