### PR TITLE
Convert to ES6 Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ For the `'?'` format character, the return value is either [true](link-to-es-tru
 ### Examples:
 A basic example of packing/unpacking three integers:
 ```javascript
-let struct = require("./struct"), s = struct('hhi'), b = new ArrayBuffer(s.size)
+import struct from "struct";
+let s = struct('hhi'), b = new ArrayBuffer(s.size)
 s.pack(1, 2, 3) // ArrayBuffer {}
 new Uint8Array(s.pack(1, 2, 3)) // Uint8Array { '0': 0, '1': 1, '2': 0, '3': 2, '4': 0, '5': 0, '6': 0, '7': 3 }
 s.unpack(new Uint8Array([0, 1, 0, 2, 0, 0, 0, 3]).buffer) // [ 1, 2, 3 ]
@@ -130,7 +131,8 @@ new Uint8Array(b) // Uint8Array { '0': 0, '1': 1, '2': 0, '3': 2, '4': 0, '5': 0
 ```
 Unpacked fields can be named by assigning them to variables:
 ```javascript
-let struct = require("./struct"), s = struct("<10sHHb")
+import struct from "struct";
+let s = struct("<10sHHb")
 let record = s.pack("Raymond   ", 4658, 264, 8)
 let [name, serialnum, school, gradelevel] = s.unpack(record)
 ```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha --harmony --harmony_destructuring --require should"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aksel/structjs",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Python struct for javascript",
   "main": "struct.mjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -37,5 +37,9 @@
     "ecmaFeatures": {
       "modules": true
     }
+  },
+  "devDependencies": {
+    "mocha": "^7.1.2",
+    "should": "^13.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@aksel/structjs",
   "version": "1.0.0",
   "description": "Python struct for javascript",
-  "main": "struct.js",
+  "main": "struct.mjs",
+  "type": "module",
   "directories": {
     "test": "test"
   },

--- a/struct.mjs
+++ b/struct.mjs
@@ -24,7 +24,7 @@ const lut = le => ({
 })
 const errbuf = new RangeError("Structure larger than remaining buffer")
 const errval = new RangeError("Not enough values for structure")
-export const struct = format => {
+export default function struct(format) {
     let fns = [], size = 0, m = rechk.exec(format)
     if (!m) { throw new RangeError("Invalid format string") }
     const t = lut('<' === m[1]), lu = (n, c) => t[c](n ? parseInt(n, 10) : 1)

--- a/struct.mjs
+++ b/struct.mjs
@@ -1,5 +1,4 @@
-/*eslint-env es6, node*/
-"use strict"
+/*eslint-env es6*/
 const rechk = /^([<>])?(([1-9]\d*)?([xcbB?hHiIfdsp]))*$/
 const refmt = /([1-9]\d*)?([xcbB?hHiIfdsp])/g
 const str = (v,o,c) => String.fromCharCode(
@@ -25,7 +24,7 @@ const lut = le => ({
 })
 const errbuf = new RangeError("Structure larger than remaining buffer")
 const errval = new RangeError("Not enough values for structure")
-const struct = format => {
+export const struct = format => {
     let fns = [], size = 0, m = rechk.exec(format)
     if (!m) { throw new RangeError("Invalid format string") }
     const t = lut('<' === m[1]), lu = (n, c) => t[c](n ? parseInt(n, 10) : 1)
@@ -58,7 +57,6 @@ const struct = format => {
     return Object.freeze({
         unpack, pack, unpack_from, pack_into, iter_unpack, format, size})
 }
-module.exports = struct
 /*
 const pack = (format, ...values) => struct(format).pack(...values)
 const unpack = (format, buffer) => struct(format).unpack(buffer)

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1,7 +1,8 @@
 /*eslint-env es6, mocha*/
-"use strict"
-require("should")
-let struct = require("../struct")
+import should from "should";
+should();
+
+import { struct } from "../struct.mjs";
 describe('struct', () => {
     let ab = new ArrayBuffer(100)
     let u8a = new Uint8Array(ab)

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -2,7 +2,7 @@
 import should from "should";
 should();
 
-import { struct } from "../struct.mjs";
+import struct from "../struct.mjs";
 describe('struct', () => {
     let ab = new ArrayBuffer(100)
     let u8a = new Uint8Array(ab)


### PR DESCRIPTION
Hey, I would like to use your library my [cdjhidjs library](https://github.com/Swiftb0y/cdjhidjs) which will be most likely be included in [Mixxx](github.com/mixxxdj/mixxx/). Because the code will run in QJSEngine instead of V8, I am limited to using ES6 imports.

I converted library and tests in my fork to use ES6 imports instead of commonjs and I figured I might open an upstream PR. What do you think?

One could still import in their nodejs code without using esm imports by using `import("<path>")` instead of `require("<path>")`.